### PR TITLE
OpenStack integration (detach a volume before trying to attach it to another node).

### DIFF
--- a/pkg/cloudprovider/providers/openstack/openstack_volumes.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_volumes.go
@@ -51,9 +51,12 @@ func (os *OpenStack) AttachDisk(instanceID string, diskName string) (string, err
 			glog.V(4).Infof("Disk: %q is already attached to compute: %q", diskName, instanceID)
 			return disk.ID, nil
 		} else {
-			errMsg := fmt.Sprintf("Disk %q is attached to a different compute: %q, should be detached before proceeding", diskName, disk.Attachments[0]["server_id"])
+			errMsg := fmt.Sprintf("Disk %q is attached to a different compute: %q, detaching", diskName, disk.Attachments[0]["server_id"])
 			glog.Errorf(errMsg)
-			return "", errors.New(errMsg)
+			err = os.DetachDisk(fmt.Sprintf("%s", disk.Attachments[0]["server_id"]), diskName)
+			if err != nil {
+				glog.Errorf(err.Error())
+			}
 		}
 	}
 	// add read only flag here if possible spothanis


### PR DESCRIPTION
**What this PR does / why we need it**: It may help to fix #33288
In a nutshell if volume is attached to another node controller-manager is not trying to detach it for some reason even though it is fully "aware" of the situation (it has information on the node that has the volume attached, the volume itself and the node that the volume should be attached to).

**Which issue this PR fixes** fixes #33288

**Special notes for your reviewer**: I'm not a go person, and my understanding of kubernetes codebase is very limited, it is more of a proof of concept than production ready fix.

**Release note**:

```
OpenStack integration: try to detach a volume before attaching if it is already attached to another compute node.
```
